### PR TITLE
new param rsyslog::config::disable_dns turns off reverse dns lookups,

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,16 @@
 #
 #  class { 'rsyslog::config': }
 #
-class rsyslog::config {
+class rsyslog::config (
+  $disable_dns = undef,
+  ) {
+
+  if $disable_dns == true {
+    $dns_config_setting = ' -x'
+  } else {
+    $dns_config_setting = undef
+  }
+
   file { $rsyslog::rsyslog_d:
     ensure  => directory,
     owner   => 'root',

--- a/templates/rsyslog_default.erb
+++ b/templates/rsyslog_default.erb
@@ -2,7 +2,9 @@
 
 <% if @rsyslog_version and @rsyslog_version.split('.')[0].to_i < 7 -%>
 # Debian, Ubuntu
-RSYSLOGD_OPTIONS="-c4"
+RSYSLOGD_OPTIONS="-c4<%= @dns_config_setting %>"
+<% else -%>
+RSYSLOGD_OPTIONS="-c4<%= @dns_config_setting %>"
 <% end -%>
 
 # CentOS, RedHat, Fedora

--- a/templates/rsyslog_default_gentoo.erb
+++ b/templates/rsyslog_default_gentoo.erb
@@ -13,4 +13,4 @@ PIDFILE="/var/run/rsyslogd.pid"
 # Notes:
 # * Do not specify another PIDFILE but use the variable above to change the location
 # * Do not specify another CONFIGFILE but use the variable above to change the location
-RSYSLOG_OPTS=""
+RSYSLOG_OPTS="<%= @dns_config_setting %>"

--- a/templates/rsyslog_default_rhel7.erb
+++ b/templates/rsyslog_default_rhel7.erb
@@ -1,2 +1,2 @@
 # File is managed by puppet
-SYSLOGD_OPTIONS=""
+SYSLOGD_OPTIONS="<%= @dns_config_setting %>"


### PR DESCRIPTION
which cause issues when using rsyslog on a log host